### PR TITLE
Raise error for wrong ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,7 +274,7 @@ module.exports = {
         'animation-fill-mode',
         'animation-play-state',
       ],
-      {'severity': 'warning'}
+      {'severity': 'error'}
     ],
   }
 }


### PR DESCRIPTION
## What

This is more of a question, but as this was called out in https://github.com/ActiveCampaign/postmark-web/pull/1107#issuecomment-1197378387 and then prompted human action in https://github.com/ActiveCampaign/postmark-web/pull/1117, should we let CI raise on wrong ordering so that authors can notice themselves and run linting as needed?